### PR TITLE
Avoid multiple meeting creation when multiple clicks on channel header or force meeting, and minor style fix.

### DIFF
--- a/webapp/src/components/icon.tsx
+++ b/webapp/src/components/icon.tsx
@@ -15,6 +15,9 @@ export default function Icon() {
                     <span
                         aria-label={ariaLabel}
                         className='icon'
+                        style={{
+                            verticalAlign: 'middle',
+                        }}
                     >
                         <svg
                             width='19'
@@ -22,9 +25,6 @@ export default function Icon() {
                             viewBox='0 0 20 20'
                             fill='none'
                             xmlns='http://www.w3.org/2000/svg'
-                            style={{
-                                verticalAlign: 'middle',
-                            }}
                         >
                             <path
                                 fillRule='evenodd'

--- a/webapp/src/components/post_type_mstmeetings/index.ts
+++ b/webapp/src/components/post_type_mstmeetings/index.ts
@@ -6,6 +6,7 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/common';
+import {ActionResult} from 'mattermost-redux/types/actions';
 import {Post} from 'mattermost-redux/types/posts';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {Theme} from 'mattermost-redux/types/preferences';
@@ -13,7 +14,6 @@ import {Theme} from 'mattermost-redux/types/preferences';
 import {startMeeting} from '../../actions';
 
 import PostTypeMSTMeetings from './post_type_mstmeetings';
-import { ActionResult } from 'mattermost-redux/types/actions';
 
 type OwnProps = {
     post: Post;

--- a/webapp/src/components/post_type_mstmeetings/index.ts
+++ b/webapp/src/components/post_type_mstmeetings/index.ts
@@ -13,6 +13,7 @@ import {Theme} from 'mattermost-redux/types/preferences';
 import {startMeeting} from '../../actions';
 
 import PostTypeMSTMeetings from './post_type_mstmeetings';
+import { ActionResult } from 'mattermost-redux/types/actions';
 
 type OwnProps = {
     post: Post;
@@ -23,7 +24,7 @@ type OwnProps = {
 }
 
 type Actions = {
-    startMeeting: (channelID: string, force: boolean) => void;
+    startMeeting: (channelID: string, force: boolean) => ActionResult;
 }
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {

--- a/webapp/src/components/post_type_mstmeetings/post_type_mstmeetings.tsx
+++ b/webapp/src/components/post_type_mstmeetings/post_type_mstmeetings.tsx
@@ -7,8 +7,8 @@ import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
 import {Post} from 'mattermost-redux/types/posts';
 import {Theme} from 'mattermost-redux/types/preferences';
 
-import {formatDate} from '../../utils/date_utils';
 import Icon from 'components/icon';
+import { ActionResult } from 'mattermost-redux/types/actions';
 
 type Props = {
     post: Post;
@@ -20,7 +20,7 @@ type Props = {
     currentChannelId: string;
     fromBot: boolean;
     actions: {
-        startMeeting: (channelID: string, force: boolean) => void;
+        startMeeting: (channelID: string, force: boolean) => ActionResult;
     };
 }
 
@@ -28,6 +28,16 @@ export default function PostTypeMSTMeetings(props: Props) {
     const style = getStyle(props.theme);
     const post = props.post;
     const postProps = post.props || {};
+
+    const [creatingMeeting, setCreatingMeeting] = React.useState(false);
+
+    const handleForceStart = async () => {
+        if (!creatingMeeting) {
+            setCreatingMeeting(true);
+            await props.actions.startMeeting(props.currentChannelId, true);
+            setCreatingMeeting(false);
+        }
+    }
 
     let preText = '';
     let content: JSX.Element | undefined;
@@ -62,7 +72,7 @@ export default function PostTypeMSTMeetings(props: Props) {
                         className='btn btn-lg btn-primary'
                         style={style.button}
                         rel='noopener noreferrer'
-                        onClick={() => props.actions.startMeeting(props.currentChannelId, true)}
+                        onClick={handleForceStart}
                     >
                         {'CREATE NEW MEETING'}
                     </a>

--- a/webapp/src/components/post_type_mstmeetings/post_type_mstmeetings.tsx
+++ b/webapp/src/components/post_type_mstmeetings/post_type_mstmeetings.tsx
@@ -4,11 +4,11 @@
 import React from 'react';
 
 import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
+import {ActionResult} from 'mattermost-redux/types/actions';
 import {Post} from 'mattermost-redux/types/posts';
 import {Theme} from 'mattermost-redux/types/preferences';
 
 import Icon from 'components/icon';
-import { ActionResult } from 'mattermost-redux/types/actions';
 
 type Props = {
     post: Post;
@@ -37,7 +37,7 @@ export default function PostTypeMSTMeetings(props: Props) {
             await props.actions.startMeeting(props.currentChannelId, true);
             setCreatingMeeting(false);
         }
-    }
+    };
 
     let preText = '';
     let content: JSX.Element | undefined;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -18,10 +18,15 @@ import {PluginRegistry} from './types/mattermost-webapp';
 
 class Plugin {
     public async initialize(registry: PluginRegistry, store: Store<GlobalState, Action<Record<string, unknown>>>) {
+        let creatingMeeting = false;
         registry.registerChannelHeaderButtonAction(
             <Icon/>,
-            (channel: Channel) => {
-                startMeeting(channel.id)(store.dispatch, store.getState);
+            async (channel: Channel) => {
+                if (!creatingMeeting) {
+                    creatingMeeting = true;
+                    await startMeeting(channel.id)(store.dispatch, store.getState);
+                    creatingMeeting = false;
+                }
             },
             'Start MS Teams Meeting',
         );


### PR DESCRIPTION
#### Summary
Avoid multiple meeting creation when multiple clicks on channel header or force meeting.
Also fix icon positioning on create meeting and force meeting posts.

#### Ticket Link
Fix #31 
