### PR TITLE
v1.0.1 version bump

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
     "description": "MS Teams Meetings audio and video conferencing plugin for Mattermost 5.2+.",
     "homepage_url": "https://mattermost.gitbook.io/microsoft-teams-pluginmsteams-meetings-plugin",
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-meetings/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-meetings/releases/tag/v1.0.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-meetings/releases/tag/v1.0.1",
     "icon_path": "assets/profile.svg",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "min_server_version": "5.26.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -6,5 +6,5 @@ import "github.com/mattermost/mattermost-server/v5/model"
 
 var manifest = model.Manifest{
 	Id:      "com.mattermost.msteamsmeetings",
-	Version: "1.0.0",
+	Version: "1.0.1",
 }


### PR DESCRIPTION
#### Summary

Bump MS Teams Calling plugin to v1.0.1

#### Improvements

d0e5b4d [MM-38103] Include professional and enterprise SKUs in license check (#51)
285052b add command icon (#54)

#### Fixes

0278e8c fix error variable issue (#52)

#### Maintenance

65aa706 go mod tidy (#48)
132b9d0 Update installation-and-configuration.md (#46)
76e4f06 Add missing period in settings help text (#44)

