### PR TITLE
[GH-53] Add Command autocomplete

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	commandHelp = `* |/mstmeetings start| - Start an MS Teams meeting.
-	* |/mstmeetings disconnect| - Disconnect from Mattermost`
+	commandHelp = "###### Mattermost MS Teams Meetings Plugin - Slash Command Help\n" +
+		"* |/mstmeetings start| - Start an MS Teams meeting. \n" +
+		"* |/mstmeetings disconnect| - Disconnect from Mattermost. \n"
 	tooManyParametersText = "Too many parameters."
 )
 
@@ -32,7 +33,22 @@ func getCommand(client *pluginapi.Client) *model.Command {
 		AutoCompleteDesc:     "Available commands: start, disconnect",
 		AutoCompleteHint:     "[command]",
 		AutocompleteIconData: iconData,
+		AutocompleteData:     getAutocompleteData(),
 	}
+}
+
+func getAutocompleteData() *model.AutocompleteData {
+	command := model.NewAutocompleteData("mstmeetings", "[command]",
+		"Available commands: start, disconnect")
+
+	start := model.NewAutocompleteData("start", "", "Start an MS Teams meeting")
+	command.AddCommand(start)
+
+	disconnect := model.NewAutocompleteData("disconnect", "",
+		"Disconnect from Mattermost")
+	command.AddCommand(disconnect)
+
+	return command
 }
 
 func (p *Plugin) postCommandResponse(args *model.CommandArgs, text string) {
@@ -72,7 +88,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 }
 
 func (p *Plugin) getHelpText() string {
-	return "###### Mattermost MS Teams Meetings Plugin - Slash Command Help\n" + strings.ReplaceAll(commandHelp, "|", "`")
+	return strings.ReplaceAll(commandHelp, "|", "`")
 }
 
 func (p *Plugin) handleHelp(args []string, extra *model.CommandArgs) (string, error) {

--- a/server/command.go
+++ b/server/command.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	commandHelp = "###### Mattermost MS Teams Meetings Plugin - Slash Command Help\n" +
+		"* |/mstmeetings help| - Display this help text. \n" +
 		"* |/mstmeetings start| - Start an MS Teams meeting. \n" +
 		"* |/mstmeetings disconnect| - Disconnect from Mattermost. \n"
 	tooManyParametersText = "Too many parameters."
@@ -30,7 +31,7 @@ func getCommand(client *pluginapi.Client) *model.Command {
 		DisplayName:          "MS Teams Meetings",
 		Description:          "Integration with MS Teams Meetings.",
 		AutoComplete:         true,
-		AutoCompleteDesc:     "Available commands: start, disconnect",
+		AutoCompleteDesc:     "Available commands: help, start, disconnect",
 		AutoCompleteHint:     "[command]",
 		AutocompleteIconData: iconData,
 		AutocompleteData:     getAutocompleteData(),
@@ -40,6 +41,9 @@ func getCommand(client *pluginapi.Client) *model.Command {
 func getAutocompleteData() *model.AutocompleteData {
 	command := model.NewAutocompleteData("mstmeetings", "[command]",
 		"Available commands: start, disconnect")
+
+	help := model.NewAutocompleteData("help", "", "Display usage information")
+	command.AddCommand(help)
 
 	start := model.NewAutocompleteData("start", "", "Start an MS Teams meeting")
 	command.AddCommand(start)


### PR DESCRIPTION
#### Summary
* Added command autocomplete for `start` and `disconnect`.
![image](https://user-images.githubusercontent.com/4560899/153767100-e906bdbb-8568-4992-af62-39d9a1b9947c.png)

* Fixed a minor cosmetic error where the a second-level bullet point would mistakenly be used:

 | Before | ![image](https://user-images.githubusercontent.com/4560899/153767312-2307a832-1ac6-4553-922a-256c72dcbed4.png) |
| ---|---|
| After | ![image](https://user-images.githubusercontent.com/4560899/153767332-3a93a993-6022-4f96-ba3d-382ac9a9a0f7.png) |


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-msteams-meetings/issues/53


