### PR TITLE
validation text changes

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -124,7 +124,7 @@ func (p *Plugin) handleDisconnect(args []string, extra *model.CommandArgs) (stri
 	}
 	err := p.disconnect(extra.UserId)
 	if err != nil {
-		return "Failed to disconnect user, " + err.Error(), nil
+		return "failed to disconnect user, " + err.Error(), nil
 	}
 
 	p.trackDisconnect(extra.UserId)

--- a/server/command.go
+++ b/server/command.go
@@ -124,7 +124,7 @@ func (p *Plugin) handleDisconnect(args []string, extra *model.CommandArgs) (stri
 	}
 	err := p.disconnect(extra.UserId)
 	if err != nil {
-		return "Failed to disconnect the user, err=" + err.Error(), nil
+		return "Failed to disconnect user, " + err.Error(), nil
 	}
 
 	p.trackDisconnect(extra.UserId)

--- a/server/store/user.go
+++ b/server/store/user.go
@@ -51,7 +51,7 @@ func (s *Store) GetUserInfo(userID string) (*UserInfo, error) {
 
 	infoBytes, appErr := s.API.KVGet(tokenKey + userID)
 	if appErr != nil || infoBytes == nil {
-		return nil, errors.New("must connect user account to Microsoft first")
+		return nil, errors.New("Connect the user account to Microsoft Teams.")
 	}
 
 	err := json.Unmarshal(infoBytes, &userInfo)

--- a/server/store/user.go
+++ b/server/store/user.go
@@ -51,7 +51,7 @@ func (s *Store) GetUserInfo(userID string) (*UserInfo, error) {
 
 	infoBytes, appErr := s.API.KVGet(tokenKey + userID)
 	if appErr != nil || infoBytes == nil {
-		return nil, errors.New("connect the user account to microsoft teams.")
+		return nil, errors.New("connect the user account to Microsoft Teams")
 	}
 
 	err := json.Unmarshal(infoBytes, &userInfo)

--- a/server/store/user.go
+++ b/server/store/user.go
@@ -51,7 +51,7 @@ func (s *Store) GetUserInfo(userID string) (*UserInfo, error) {
 
 	infoBytes, appErr := s.API.KVGet(tokenKey + userID)
 	if appErr != nil || infoBytes == nil {
-		return nil, errors.New("connect the user account to Microsoft Teams")
+		return nil, errors.New("your Mattermost account is not connected to any Microsoft Teams account")
 	}
 
 	err := json.Unmarshal(infoBytes, &userInfo)

--- a/server/store/user.go
+++ b/server/store/user.go
@@ -51,7 +51,7 @@ func (s *Store) GetUserInfo(userID string) (*UserInfo, error) {
 
 	infoBytes, appErr := s.API.KVGet(tokenKey + userID)
 	if appErr != nil || infoBytes == nil {
-		return nil, errors.New("Connect the user account to Microsoft Teams.")
+		return nil, errors.New("connect the user account to microsoft teams.")
 	}
 
 	err := json.Unmarshal(infoBytes, &userInfo)


### PR DESCRIPTION
This PR main point was to remove the **err=** Text From this validation message as "Failed to disconnect the user, **err=**must connect user account to Microsoft first" But after Discussion with cwarnermm, Now we have different validation message as **"Failed to disconnect user, Connect the user account to Microsoft Teams."**
This validation generate when User is already disconnected with Msteam-plugin and Try again to disconnect then User will get that validation.

**if anyone feels like the old validation message was proper and i should only remove "err=" then pls let me know.**

ticket here
Fixes https://github.com/mattermost/mattermost-plugin-msteams-meetings/issues/65