### PR TITLE
Fix linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,18 +3,15 @@ run:
   modules-download-mode: readonly
 
 linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 2
   gofmt:
     simplify: true
   goimports:
     local-prefixes: github.com/mattermost/mattermost-plugin-msteams-meetings
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - fieldalignment
   misspell:
     locale: US
 
@@ -22,41 +19,30 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
-    - goconst
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nakedret
+    - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 issues:
   exclude-rules:
-    - path: server/manifest.go
-      linters:
-        - deadcode
-        - unused
-        - varcheck
     - path: server/configuration.go
       linters:
         - unused
     - path: _test\.go
       linters:
         - bodyclose
-        - goconst
         - scopelint # https://github.com/kyoh86/scopelint/issues/4

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -78,7 +78,7 @@ func (p *Plugin) OnActivate() error {
 		return errors.WithMessage(err, "OnActivate: failed to register command")
 	}
 
-	profileImage, err := ioutil.ReadFile(filepath.Join(bundlePath, "assets", "profile.png"))
+	profileImage, err := os.ReadFile(filepath.Join(bundlePath, "assets", "profile.png"))
 	if err != nil {
 		return errors.Wrap(err, "couldn't read profile image")
 	}


### PR DESCRIPTION
#### Summary
Fix linter errors caused by `golangci-lint` update.

#### Ticket Link
None