### PR TITLE
Remove license restrictions from docs

### DIFF
--- a/docs/setup/installation-and-configuration.md
+++ b/docs/setup/installation-and-configuration.md
@@ -5,7 +5,6 @@ The Mattermost MS Teams Meetings plugin is provided in the Mattermost Plugin Mar
 ### Requirements
 
 * Mattermost Server v5.26+ is required.
-* Mattermost Enterprise Edition E20 is required.
 
 ### Marketplace Installation
 
@@ -31,7 +30,7 @@ If your server doesn't have access to the internet, you can download the latest 
 
     - Name: **Mattermost MS Teams Meetings Plugin**
     - Supported account types: **Default value (Single tenant)**
-    - Redirect URI: **https://(MM_SITE_URL)/plugins/com.mattermost.msteamsmeetings/oauth2/complete**. Replace `(MM_SITE_URL)` with your Mattermost server's URL. 
+    - Redirect URI: **https://(MM_SITE_URL)/plugins/com.mattermost.msteamsmeetings/oauth2/complete**. Replace `(MM_SITE_URL)` with your Mattermost server's URL.
 
 5. Select **Register** to submit the form.
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Removes the E20 license requirement from the installation docs as an Enterprise License [is no longer needed](https://github.com/mattermost/mattermost-plugin-msteams-meetings/pull/80)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Closes #85
