### PR TITLE
Replaced legacy GitBook URLs with PL links

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.msteamsmeetings",
     "name": "MS Teams Meetings",
     "description": "MS Teams Meetings audio and video conferencing plugin for Mattermost 5.2+.",
-    "homepage_url": "https://mattermost.gitbook.io/microsoft-teams-pluginmsteams-meetings-plugin",
+    "homepage_url": "https://mattermost.com/pl/mattermost-plugin-msteams-meetings",
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-meetings/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-msteams-meetings/releases/tag/v2.1.0",
     "icon_path": "assets/profile.svg",
@@ -20,7 +20,7 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "Please refer to installation instructions [**here**](https://app.gitbook.com/@mattermost/s/microsoft-teams-pluginmsteams-meetings-plugin/setup/installation-and-configuration) for creating a new Application in the Azure Portal.",
+        "header": "Please refer to installation instructions [**here**](https://mattermost.com/pl/mattermost-plugin-msteams-meetings) for creating a new Application in the Azure Portal.",
         "footer": "",
         "settings": [
             {


### PR DESCRIPTION
Replaced legacy/broken GitBook links with permalinks [via Marketing](https://docs.google.com/spreadsheets/d/1O601H_A0IM8pR3FOfue29_C8flGV7xK3ts-tJUVDHHg/edit#gid=0).

Addresses: https://mattermost.atlassian.net/browse/MM-55436