### PR TITLE
Update CODEOWNERS for Integrations team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @mattermost/deployment-engineering
+* @mattermost/integrations
 


### PR DESCRIPTION
#### Summary
Add `@mattermost/integrations` to CODEOWNERS

**Note** the `@mattermost/integrations` team must be added to the repo by an admin. 

#### Ticket Link
NONE