### PR TITLE
MM-67814 Fixing issue with hoisting causing base path for client to be empty

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -16,6 +16,21 @@ import Client from './client';
 // eslint-disable-next-line import/no-unresolved
 import {PluginRegistry} from './types/mattermost-webapp';
 
+function getServerRoute(state: GlobalState) {
+    const config = getConfig(state);
+
+    let basePath = '';
+    if (config && config.SiteURL) {
+        basePath = new URL(config.SiteURL).pathname;
+
+        if (basePath && basePath[basePath.length - 1] === '/') {
+            basePath = basePath.substr(0, basePath.length - 1);
+        }
+    }
+
+    return basePath;
+}
+
 class Plugin {
     public async initialize(registry: PluginRegistry, store: Store<GlobalState, Action<Record<string, unknown>>>) {
         const helpText = 'Start MS Teams Meeting';
@@ -51,18 +66,3 @@ declare global {
 }
 
 window.registerPlugin(pluginId, new Plugin());
-
-const getServerRoute = (state: GlobalState) => {
-    const config = getConfig(state);
-
-    let basePath = '';
-    if (config && config.SiteURL) {
-        basePath = new URL(config.SiteURL).pathname;
-
-        if (basePath && basePath[basePath.length - 1] === '/') {
-            basePath = basePath.substr(0, basePath.length - 1);
-        }
-    }
-
-    return basePath;
-};


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR fixes an issue where the API path for the plugin would not be set properly in the client due to hoisting issues with getServerRoute (created as a `const` in the bottom of the script), which caused requests to start a meeting via the app bar to return a 404 error

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-67814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a targeted bug fix that relocates the `getServerRoute` helper function definition from the bottom of the file to the top (before the Plugin class), resolving a JavaScript hoisting issue. The function logic remains identical; only the declaration order changes to ensure the function is available when `Client.setServerRoute()` is called during plugin initialization.

**Regression Risk:** Minimal. The fix addresses the root cause of the reported bug (empty base path causing 404 errors) by ensuring the function is properly defined before use. Since the previous behavior was broken, the corrected version eliminates an actual defect with no risk of introducing new regressions. The change touches only initialization logic in a single file with no shared dependencies affected.

**QA Recommendation:** Light manual QA focused on the fixed flow: verify that starting a meeting via the app bar no longer returns 404 errors and that requests include the correct server path. Basic smoke testing of the app bar icon action is sufficient given the isolated, well-understood nature of the fix. Risk to skip manual QA is acceptable for this straightforward hoisting correction.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->