### PR TITLE
Add linux ARM64 executable to plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -10,7 +10,8 @@
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",
             "linux-amd64": "server/dist/plugin-linux-amd64",
-            "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+            "windows-amd64": "server/dist/plugin-windows-amd64.exe",
+            "linux-arm64": "server/dist/plugin-linux-arm64"
         },
         "executable": ""
     },


### PR DESCRIPTION
#### Summary

The plugin fails to activate on ARM64 mattermost instances due to a missing `linux-arm64` executable path in `plugin.json`. This patch adds it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is an isolated configuration file change that adds support for two additional server architectures (linux-arm64 and windows-amd64) without modifying any code logic or affecting existing functionality on supported architectures.

**Regression Risk:** Minimal. The changes are purely additive to the `server.executables` mapping in `plugin.json`. Existing architecture entries (darwin-amd64, linux-amd64) remain unchanged, so current deployments are unaffected. If the corresponding binaries don't exist, the plugin simply won't activate on those architectures—the same failure mode as before.

**QA Recommendation:** Manual QA is recommended only for environments deployed on linux-arm64 and windows-amd64 architectures to verify that the referenced executables exist and the plugin activates correctly. For all other platforms, QA can be safely skipped as there are no behavioral changes. The change has negligible risk of impacting other systems or architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->